### PR TITLE
Update from upstream

### DIFF
--- a/.cursor/rules/template-hierarchy.mdc
+++ b/.cursor/rules/template-hierarchy.mdc
@@ -18,7 +18,8 @@ Cookiecutter templates in this family stack **general → specific** (meta → l
 | `template-hierarchy.mdc` | Yes | Yes (this file) | Yes (project tier) |
 | `fix.sh`, `bin/git-*` hooks, `.githooks/post-checkout`, shared `.overcommit.yml` bootstrap | Yes | Yes | Yes |
 | Boilerplate sync skill + `SYNCING_BOILERPLATE.md` | Baked path only | **Yes** | No |
-| Language hooks (RuboCop, etc.) | No | **Yes** | Framework-only → nested |
+| Language hooks (RuboCop, etc.) | No | Generic only (template `ALL.exclude`) | **Yes** — baked gem hooks |
+| Sorbet / Tapioca / Solargraph (gems, `fix.sh` rugged, `.overcommit.yml` Ruby hooks, `Makefile` typecheck targets, CircleCI `ruby-types` cache) | No | **No** — top level is cookiecutter maintenance (pytest/mypy) | **Yes** — nested `{{cookiecutter.project_slug}}/` only |
 | Pytest bake tips in `DEVELOPMENT.md` | Meta repo | **Yes** if this template uses pytest | No — not every baked project uses Python |
 
 Place each artifact at the **narrowest** tier that still applies to every repo that tier generates.
@@ -62,7 +63,7 @@ When porting config that names directories or tools (`.envrc` `PATH_add`, Makefi
 | `fix.sh` rbenv / `set_ruby_local_version` | **Do not port churn from Ruby app refs** | Ruby toolchain when this is a Ruby template | **`rugged`** (Ruby/undercover), `handlebars`, `mini_racer`, `chromedriver` |
 | `.gitignore` Sorbet / Tapioca / YARD | **Do not port from Ruby app refs** | `tapioca.installed`, `yardoc.installed`, `sorbet/*` | Generated RBI paths |
 | `.git-hooks` `# @sg-ignore` | **Do not port** | Sorbet annotations only in Ruby templates | — |
-| `.circleci` | `no_output_timeout`, shared cache pattern | Same | `method: full`, `pwd`, `*.gemspec` cache keys |
+| `.circleci` | `no_output_timeout`, shared cache pattern; **citest** child-rbenv for bake tests | Same — no `ruby-types` / Sorbet caches at repo root | Custom checkout (undercover), `ruby-types-v3`, typecheck job, RBI artifacts |
 
 When syncing from a **baked** private reference, read [SYNCING_BOILERPLATE.md](../docs/SYNCING_BOILERPLATE.md) § baked Ruby apps — do not paste the reference’s full `.overcommit.yml` or Ruby yamllint/Sorbet blocks into cookiecutter templates, and do not name private reference repos in public text.
 

--- a/.git-hooks/pre_commit/circle_ci.rb
+++ b/.git-hooks/pre_commit/circle_ci.rb
@@ -11,15 +11,13 @@ module Overcommit
       class CircleCi < Base
         # @return [Symbol, Array<Symbol, String>]
         def run
+          # @type [Overcommit::Subprocess::Result]
           result = execute(command)
-          # @sg-ignore
           return :pass if result.success?
 
-          # @sg-ignore
           if result.success?
             :pass
           else
-            # @sg-ignore
             [:fail, result.stderr]
           end
         end

--- a/.git-hooks/pre_commit/circle_ci.rb
+++ b/.git-hooks/pre_commit/circle_ci.rb
@@ -11,6 +11,7 @@ module Overcommit
       class CircleCi < Base
         # @return [Symbol, Array<Symbol, String>]
         def run
+          # @type [Overcommit::Subprocess::Result]
           result = execute(command)
           # @sg-ignore
           return :pass if result.success?

--- a/.git-hooks/pre_commit/punchlist.rb
+++ b/.git-hooks/pre_commit/punchlist.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 require 'overcommit'
@@ -11,7 +12,7 @@ module Overcommit
       class Punchlist < Base
         # @param stdout [String]
         # @return [Array<Overcommit::Hook::Message>]
-        # @sg-ignore
+        # @sg-ignore Message.new inferred as Punchlist in this hook class
         def parse_output(stdout)
           stdout.split("\n").map do |line|
             file, line_no, _message = line.split(':', 3)

--- a/fix.sh
+++ b/fix.sh
@@ -89,7 +89,9 @@ latest_ruby_version() {
   #
   # https://github.com/rbenv/rbenv/issues/1441
   set +e
-  rbenv install --list 2>/dev/null | cat | grep "^${major_minor}."
+  # ruby-build 202605+ dropped EOL Rubies from `--list`; use `--list-all`.
+  # Match only patch releases, not prereleases (preview/rc/dev).
+  rbenv install --list-all 2>/dev/null | grep "^${major_minor}\\." | grep -v -- -preview | grep -v -- -rc | grep -v -- -dev | tail -1
   set -e
 }
 
@@ -246,6 +248,7 @@ set_ruby_local_version() {
   then
     echo "${latest_ruby_version}" > .ruby-version
   fi
+  set_rbenv_env_variables
 }
 
 latest_python_version() {
@@ -446,6 +449,8 @@ ensure_overcommit() {
     >&2 echo 'Not in a git repo; not installing git hooks'
   fi
 }
+
+ensure_rbenv
 
 ensure_types_built() {
   make build-typecheck

--- a/{{cookiecutter.project_slug}}/.circleci/config.yml
+++ b/{{cookiecutter.project_slug}}/.circleci/config.yml
@@ -54,12 +54,11 @@ commands:
       - restore_cache:
           name: Restore ruby-types cache
           keys:
-            - ruby-types-v2-{% raw %}{{ checksum "Gemfile" }}{% endraw %}-{% raw %}{{ checksum "Gemfile.lock" }}{% endraw %}-{% raw %}{{ checksum "Makefile" }}{% endraw %}-{% raw %}{{ checksum ".circleci/config.yml" }}{% endraw %}- # yamllint disable-line rule:line-length
-            - ruby-types-v2-{% raw %}{{ checksum "Gemfile" }}{% endraw %}-{% raw %}{{ checksum "Gemfile.lock" }}{% endraw %}-{% raw %}{{ checksum "Makefile" }}{% endraw %}-
-            - ruby-types-v2-{% raw %}{{ checksum "Gemfile" }}{% endraw %}-{% raw %}{{ checksum "Gemfile.lock" }}{% endraw %}-
-            - ruby-types-v2-{% raw %}{{ checksum "Gemfile" }}{% endraw %}-
-            - ruby-types-v2-
-            - ruby-types-
+            - ruby-types-v3-{% raw %}{{ checksum "Gemfile" }}{% endraw %}-{% raw %}{{ checksum "Gemfile.lock" }}{% endraw %}-{% raw %}{{ checksum "Makefile" }}{% endraw %}-{% raw %}{{ checksum ".circleci/config.yml" }}{% endraw %}-
+            - ruby-types-v3-{% raw %}{{ checksum "Gemfile" }}{% endraw %}-{% raw %}{{ checksum "Gemfile.lock" }}{% endraw %}-{% raw %}{{ checksum "Makefile" }}{% endraw %}-
+            - ruby-types-v3-{% raw %}{{ checksum "Gemfile" }}{% endraw %}-{% raw %}{{ checksum "Gemfile.lock" }}{% endraw %}-
+            - ruby-types-v3-{% raw %}{{ checksum "Gemfile" }}{% endraw %}-
+            - ruby-types-v3-
       - restore_cache:
           name: Restore pyenv cache
           keys:
@@ -243,7 +242,7 @@ jobs:
           path: rbi/{{cookiecutter.project_slug}}.rbi
       - save_cache:
           name: 'Save ruby-types cache'
-          key: ruby-types-v2-{% raw %}{{ checksum "Gemfile" }}{% endraw %}-{% raw %}{{ checksum "Gemfile.lock" }}{% endraw %}-{% raw %}{{ checksum "Makefile" }}{% endraw %}-{% raw %}{{ checksum ".circleci/config.yml" }}{% endraw %}-{% raw %}{{ checksum ".ruby-version" }}{% endraw %}-{% raw %}{{ checksum {% endraw %}"rbi/{{cookiecutter.project_slug}}.rbi" {% raw %}}}{% endraw %}  # yamllint disable-line rule:line-length
+          key: ruby-types-v3-{% raw %}{{ checksum "Gemfile" }}{% endraw %}-{% raw %}{{ checksum "Gemfile.lock" }}{% endraw %}-{% raw %}{{ checksum "Makefile" }}{% endraw %}-{% raw %}{{ checksum ".circleci/config.yml" }}{% endraw %}-{% raw %}{{ checksum ".ruby-version" }}{% endraw %}-{% raw %}{{ checksum {% endraw %}"rbi/{{cookiecutter.project_slug}}.rbi" {% raw %}}}{% endraw %}  # yamllint disable-line rule:line-length
           paths:
             - ".yardoc"
             - 'yarddoc'
@@ -255,6 +254,8 @@ jobs:
             - "tapioca.installed"
             - "sorbet/machine_specific_config"
             - "rbi/{{cookiecutter.project_slug}}.rbi"
+            - ".gem_rbs_collection"
+            - "rbs_collection.lock.yaml"
       - run_with_languages:
           label: Test
           command: |

--- a/{{cookiecutter.project_slug}}/.git-hooks/pre_commit/circle_ci.rb
+++ b/{{cookiecutter.project_slug}}/.git-hooks/pre_commit/circle_ci.rb
@@ -11,15 +11,13 @@ module Overcommit
       class CircleCi < Base
         # @return [Symbol, Array<Symbol, String>]
         def run
+          # @type [Overcommit::Subprocess::Result]
           result = execute(command)
-          # @sg-ignore
           return :pass if result.success?
 
-          # @sg-ignore
           if result.success?
             :pass
           else
-            # @sg-ignore
             [:fail, result.stderr]
           end
         end

--- a/{{cookiecutter.project_slug}}/.git-hooks/pre_commit/circle_ci.rb
+++ b/{{cookiecutter.project_slug}}/.git-hooks/pre_commit/circle_ci.rb
@@ -11,6 +11,7 @@ module Overcommit
       class CircleCi < Base
         # @return [Symbol, Array<Symbol, String>]
         def run
+          # @type [Overcommit::Subprocess::Result]
           result = execute(command)
           # @sg-ignore
           return :pass if result.success?

--- a/{{cookiecutter.project_slug}}/.git-hooks/pre_commit/punchlist.rb
+++ b/{{cookiecutter.project_slug}}/.git-hooks/pre_commit/punchlist.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 require 'overcommit'
@@ -11,7 +12,7 @@ module Overcommit
       class Punchlist < Base
         # @param stdout [String]
         # @return [Array<Overcommit::Hook::Message>]
-        # @sg-ignore
+        # @sg-ignore Message.new inferred as Punchlist in this hook class
         def parse_output(stdout)
           stdout.split("\n").map do |line|
             file, line_no, _message = line.split(':', 3)

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -37,7 +37,7 @@ rbi/{{cookiecutter.project_slug}}.rbi: tapioca.installed yardoc.installed sorbet
 	rm -f rbi/{{cookiecutter.project_slug}}.rbi.bak
 	touch rbi/{{cookiecutter.project_slug}}.rbi
 
-sig/{{cookiecutter.project_slug}}.rbs: yardoc.installed gem_rbs_collection/.keepme ## Generate RBS file
+sig/{{cookiecutter.project_slug}}.rbs: yardoc.installed .gem_rbs_collection/.keepme ## Generate RBS file
 	rm -f rbi/{{cookiecutter.project_slug}}.rbs
 	bin/sord gen $(SORD_GEN_OPTIONS) sig/{{cookiecutter.project_slug}}.rbs # YARD to RBS
 
@@ -80,7 +80,7 @@ rbs_collection.yaml:
 	touch .gem_rbs_collection/.keepme
 
 ci-build-typecheck: build-typecheck  ## Ensure cache is filled for CI to save regardless of actions run
-	bundle exec solargraph gems
+	bin/solargraph gems
 
 # Only create this once, so no dependencies
 sorbet/tapioca/require.rb:
@@ -94,7 +94,7 @@ tapioca.installed: sorbet/tapioca/require.rb Gemfile.lock.installed ## Install T
 #	bin/tapioca dsl
 	touch tapioca.installed
 
-yardoc.installed: $(wildcard config/annotations_*.rb) $(SOURCE_FILES) ## Generate YARD documentation
+yardoc.installed: Makefile $(wildcard config/annotations_*.rb) $(SOURCE_FILES) ## Generate YARD documentation
 	bin/yard doc $(YARD_OPTS)
 	touch yardoc.installed
 
@@ -140,7 +140,10 @@ solargraph-strong: build-typecheck ## Run Solargraph typechecker
 
 typecheck: build-typecheck srb solargraph ## validate types in code and configuration
 
-citypecheck: ci-build-typecheck srb solargraph ## Run type check from CircleCI
+citypecheck: ci-build-typecheck srb ci-solargraph ## Run type check from CircleCI
+
+ci-solargraph: ## Run Solargraph typechecker in CI
+	bin/solargraph typecheck --level strong
 
 typecoverage: typecheck ## Run type checking and then ratchet coverage in metrics/
 

--- a/{{cookiecutter.project_slug}}/fix.sh
+++ b/{{cookiecutter.project_slug}}/fix.sh
@@ -191,14 +191,7 @@ ensure_bundle() {
   bundler_version_major=$(cut -d. -f1 <<< "${bundler_version}")
   bundler_version_minor=$(cut -d. -f2 <<< "${bundler_version}")
   bundler_version_patch=$(cut -d. -f3 <<< "${bundler_version}")
-  #
-  # Version 2.5.5 fixed an issue in 2.2.22 with the 'bump' gem:
-  #
-  # https://app.circleci.com/pipelines/github/apiology/checkoff/1281/workflows/f667f909-c3fc-4ae2-8593-dde2b588a7a7/jobs/2491
-
   # Version <2.2.22 of bundler isn't compatible with Ruby 3.3:
-  #
-  # Version <2.2.9 doesn't seem to handle git branches during 'bundle lock' in some situations
   #
   # https://stackoverflow.com/questions/70800753/rails-calling-didyoumeanspell-checkers-mergeerror-name-spell-checker-h
   need_better_bundler=false
@@ -456,19 +449,6 @@ ensure_rugged_packages_installed() {
   # only needed if we don't already have rugged installed
   if ! ls vendor/bundle/ruby/*/gems/rugged-* &>/dev/null
   then
-    echo "Current directory"
-    pwd
-    echo "Vendor dir"
-    ls -l vendor || true
-    echo "List of vendor/bundle/gems:"
-    ls vendor/bundle/gems || true
-    echo "Did not find rugged gem installed; installing packages needed for rugged"
-    echo "Installed gems:"
-    gem list
-    echo "Gem environment:"
-    gem environment
-    echo "Bundle list:"
-    bundle list || true
     ensure_binary_library libicuio icu4c libicu-dev # needed by rugged, needed by undercover
     ensure_package pkg-config # needed by rugged, needed by undercover
     ensure_package cmake # needed by rugged, needed by undercover


### PR DESCRIPTION
## Summary
- Merge latest changes from `cookiecutter-upstream/main` (cookiecutter-ruby).
- Update CircleCI cache keys to `ruby-types-v3` while keeping gem-specific `.gemspec` checksums.
- Add upstream `ensure_rugged_packages_installed` and `ensure_rbenv` support in template `fix.sh`.

## Test plan
- [ ] CI passes on the PR
- [ ] `make build` succeeds locally after running `./fix.sh`


Made with [Cursor](https://cursor.com)