### PR TITLE
Sync nested Ruby tier typecheck and CI feedback rules

### DIFF
--- a/{{cookiecutter.project_slug}}/.cursor/rules/ci-failure-feedback-loop.mdc
+++ b/{{cookiecutter.project_slug}}/.cursor/rules/ci-failure-feedback-loop.mdc
@@ -1,0 +1,15 @@
+---
+description: On failed CircleCI checks, fetch logs first and share one concrete error before broad local retries
+globs: .circleci/**,Makefile,**/*.rb,test/**/*.rb
+alwaysApply: false
+---
+
+# CI failure feedback loop
+
+When `gh pr checks` shows a failed CircleCI check:
+
+1. Fetch the failing step logs first (prefer MCP `user-circleci-mcp-server`).
+2. Share one exact failing error line with the user before broad local retries.
+3. Fix from that error message, then push and re-watch checks.
+
+Avoid long local loops (`make citest`, full quality/build) before reading remote failure text.

--- a/{{cookiecutter.project_slug}}/.cursor/rules/typecheck-test-fixes.mdc
+++ b/{{cookiecutter.project_slug}}/.cursor/rules/typecheck-test-fixes.mdc
@@ -1,0 +1,20 @@
+---
+description: Gradual typing fixes — Sorbet block locals, tests, RuboCop, and undercover gates
+globs: lib/**/*.rb,test/**/*.rb,.overcommit.yml,rakelib/**,sorbet/**
+alwaysApply: false
+---
+
+# Typecheck fixes (Sorbet + CI gates)
+
+## Sorbet: locals mutated inside blocks
+
+When Sorbet typechecks a file in `lib/` or `test/` and a local is updated inside a block (callback, `yield`, etc.), initialize with an explicit type if literals would narrow too far—e.g. `flag = T.let(false, T::Boolean)` before assigning `true` in the block.
+
+## Tests and CI
+
+When typechecking work adds or edits code:
+
+- Run the same CI gates locally where possible (`make citypecheck`, tests, coverage/undercover gate).
+- Apply the block-local rule when callbacks/blocks flip flags or similar.
+- Run RuboCop on new tests before push (Minitest cops often fail on small formatting details).
+- New or changed instance methods under `lib/` need coverage in `test/unit/` for undercover.


### PR DESCRIPTION
## Summary

- Add **ci-failure-feedback-loop** and **typecheck-test-fixes** under nested `{{cookiecutter.project_slug}}/.cursor/rules/` from [cookiecutter-ruby #362](https://github.com/apiology/cookiecutter-ruby/pull/362).
- Baked gems (e.g. plate-spinner) already picked these up via [plate-spinner #2122](https://github.com/apiology/plate-spinner/pull/2122); this aligns the language-tier template for future `update_from_cookiecutter` runs.

## Test plan

- [ ] CI green