### PR TITLE
Sync boilerplate from baked gem reference

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,7 @@ commands:
             - pyenv-
       - run:
           name: Initialize packages
+          no_output_timeout: 30m
           command: |
             # measuring slows down the script - only enable when you
             # want to debug where this is spending time

--- a/fix.sh
+++ b/fix.sh
@@ -243,7 +243,7 @@ ensure_bundle() {
 }
 
 set_ruby_local_version() {
-  latest_ruby_version="$(cut -d' ' -f1 <<< "${ruby_versions}")"
+  latest_ruby_version="$(echo "${ruby_versions}" | tail -1)"
   if [ "${latest_ruby_version}" != "$(cat .ruby-version 2>/dev/null)" ]
   then
     echo "${latest_ruby_version}" > .ruby-version

--- a/{{cookiecutter.project_slug}}/.circleci/config.yml
+++ b/{{cookiecutter.project_slug}}/.circleci/config.yml
@@ -53,15 +53,16 @@ commands:
             - rbenv-v5-
             - rbenv-
       - restore_cache:
+          # NOTE: bump the ruby-types-vN- prefix when YARD_OPTS changes in
+          # the Makefile (see the comment there for why).
           name: Restore ruby-types cache
           keys:
-            - ruby-types-v3-{% raw %}{{ checksum {% endraw %}"{{cookiecutter.project_slug}}.gemspec" {% raw %}}}{% endraw %}-{% raw %}{{ checksum "Gemfile" }}{% endraw %}-{% raw %}{{ checksum "Gemfile.lock" }}{% endraw %}-{% raw %}{{ checksum "Makefile" }}{% endraw %}-{% raw %}{{ checksum ".circleci/config.yml" }}{% endraw %}- # yamllint disable-line rule:line-length
-            - ruby-types-v3-{% raw %}{{ checksum {% endraw %}"{{cookiecutter.project_slug}}.gemspec" {% raw %}}}{% endraw %}-{% raw %}{{ checksum "Gemfile" }}{% endraw %}-{% raw %}{{ checksum "Gemfile.lock" }}{% endraw %}-{% raw %}{{ checksum "Makefile" }}{% endraw %}- # yamllint disable-line rule:line-length
-            - ruby-types-v3-{% raw %}{{ checksum {% endraw %}"{{cookiecutter.project_slug}}.gemspec" {% raw %}}}{% endraw %}-{% raw %}{{ checksum "Gemfile" }}{% endraw %}-{% raw %}{{ checksum "Gemfile.lock" }}{% endraw %}- # yamllint disable-line rule:line-length
-            - ruby-types-v3-{% raw %}{{ checksum {% endraw %}"{{cookiecutter.project_slug}}.gemspec" {% raw %}}}{% endraw %}-{% raw %}{{ checksum "Gemfile" }}{% endraw %}-
-            - ruby-types-v3-{% raw %}{{ checksum {% endraw %}"{{cookiecutter.project_slug}}.gemspec" {% raw %}}}{% endraw %}-
-            - ruby-types-v3-
-            - ruby-types-
+            - ruby-types-v11-{% raw %}{{ checksum {% endraw %}"{{cookiecutter.project_slug}}.gemspec" {% raw %}}}{% endraw %}-{% raw %}{{ checksum "Gemfile" }}{% endraw %}-{% raw %}{{ checksum "Gemfile.lock" }}{% endraw %}-{% raw %}{{ checksum "rbs_collection.lock.yaml" }}{% endraw %}-{% raw %}{{ checksum "Makefile" }}{% endraw %}-{% raw %}{{ checksum ".circleci/config.yml" }}{% endraw %}- # yamllint disable-line rule:line-length
+            - ruby-types-v11-{% raw %}{{ checksum {% endraw %}"{{cookiecutter.project_slug}}.gemspec" {% raw %}}}{% endraw %}-{% raw %}{{ checksum "Gemfile" }}{% endraw %}-{% raw %}{{ checksum "Gemfile.lock" }}{% endraw %}-{% raw %}{{ checksum "Makefile" }}{% endraw %}- # yamllint disable-line rule:line-length
+            - ruby-types-v11-{% raw %}{{ checksum {% endraw %}"{{cookiecutter.project_slug}}.gemspec" {% raw %}}}{% endraw %}-{% raw %}{{ checksum "Gemfile" }}{% endraw %}-{% raw %}{{ checksum "Gemfile.lock" }}{% endraw %}- # yamllint disable-line rule:line-length
+            - ruby-types-v11-{% raw %}{{ checksum {% endraw %}"{{cookiecutter.project_slug}}.gemspec" {% raw %}}}{% endraw %}-{% raw %}{{ checksum "Gemfile" }}{% endraw %}-
+            - ruby-types-v11-{% raw %}{{ checksum {% endraw %}"{{cookiecutter.project_slug}}.gemspec" {% raw %}}}{% endraw %}-
+            - ruby-types-v11-
       - restore_cache:
           name: Restore pyenv cache
           keys:
@@ -70,6 +71,7 @@ commands:
             - pyenv-
       - run:
           name: Initialize packages
+          no_output_timeout: 30m
           command: |
             # measuring slows down the script - only enable when you
             # want to debug where this is spending time
@@ -245,10 +247,10 @@ jobs:
           path: rbi/{{cookiecutter.project_slug}}.rbi
       - save_cache:
           name: 'Save ruby-types cache'
-          key: ruby-types-v3-{% raw %}{{ checksum {% endraw %}"{{cookiecutter.project_slug}}.gemspec" {% raw %}}}{% endraw %}-{% raw %}{{ checksum "Gemfile" }}{% endraw %}-{% raw %}{{ checksum "Gemfile.lock" }}{% endraw %}-{% raw %}{{ checksum "Makefile" }}{% endraw %}-{% raw %}{{ checksum ".circleci/config.yml" }}{% endraw %}-{% raw %}{{ checksum ".ruby-version" }}{% endraw %}-{% raw %}{{ checksum {% endraw %}"rbi/{{cookiecutter.project_slug}}.rbi" {% raw %}}}{% endraw %}  # yamllint disable-line rule:line-length
+          key: ruby-types-v11-{% raw %}{{ checksum {% endraw %}"{{cookiecutter.project_slug}}.gemspec" {% raw %}}}{% endraw %}-{% raw %}{{ checksum "Gemfile" }}{% endraw %}-{% raw %}{{ checksum "Gemfile.lock" }}{% endraw %}-{% raw %}{{ checksum "rbs_collection.lock.yaml" }}{% endraw %}-{% raw %}{{ checksum "Makefile" }}{% endraw %}-{% raw %}{{ checksum ".circleci/config.yml" }}{% endraw %}-{% raw %}{{ checksum ".ruby-version" }}{% endraw %}-{% raw %}{{ checksum {% endraw %}"rbi/{{cookiecutter.project_slug}}.rbi" {% raw %}}}{% endraw %}  # yamllint disable-line rule:line-length
           paths:
             - ".yardoc"
-            - 'yarddoc'
+            - "yardoc"
             - "/home/circleci/.cache/solargraph"
             - "/home/circleci/.sorbet-cache"
             - "/home/circleci/.cache/sorbet"

--- a/{{cookiecutter.project_slug}}/.gitignore
+++ b/{{cookiecutter.project_slug}}/.gitignore
@@ -81,3 +81,4 @@ sorbet/machine_specific_config
 
 # Ignore 1Password-generated secrets
 /config/env
+/config/env.local

--- a/{{cookiecutter.project_slug}}/.overcommit.yml
+++ b/{{cookiecutter.project_slug}}/.overcommit.yml
@@ -90,6 +90,7 @@ PreCommit:
     enabled: true
   Solargraph:
     enabled: true
+    command: ['bin/solargraph']
     problem_on_unmodified_line: warn
     include:
       # process first

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -33,7 +33,7 @@ rbi/{{cookiecutter.project_slug}}.rbi: tapioca.installed yardoc.installed sorbet
 	bin/sord gen $(SORD_GEN_OPTIONS) rbi/{{cookiecutter.project_slug}}-sord.rbi # YARD to RBI
 	cat rbi/{{cookiecutter.project_slug}}-parlour.rbi rbi/{{cookiecutter.project_slug}}-sord.rbi > rbi/{{cookiecutter.project_slug}}.rbi
 	rm -f rbi/{{cookiecutter.project_slug}}-sord.rbi rbi/{{cookiecutter.project_slug}}-parlour.rbi
-	sed -i.bak -e 's/^# typed: strong/# typed: ignore/' rbi/{{cookiecutter.project_slug}}.rbi
+#	sed -i.bak -e 's/^# typed: strong/# typed: ignore/' rbi/{{cookiecutter.project_slug}}.rbi
 	rm -f rbi/{{cookiecutter.project_slug}}.rbi.bak
 	touch rbi/{{cookiecutter.project_slug}}.rbi
 

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -81,8 +81,8 @@ rbs_collection.lock.yaml: Gemfile.lock rbs_collection.yaml
 	bin/rbs collection update
 	touch rbs_collection.lock.yaml
 
-rbs_collection.yaml:
-	bin/rbs collection init
+rbs_collection.yaml: Gemfile.lock.installed
+	@if [ ! -f rbs_collection.yaml ]; then bin/rbs collection init; fi
 
 .gem_rbs_collection/.keepme: rbs_collection.lock.yaml
 	# Ensure that the gem rbs collection is installed
@@ -104,7 +104,7 @@ tapioca.installed: sorbet/tapioca/require.rb Gemfile.lock.installed ## Install T
 #	bin/tapioca dsl
 	touch tapioca.installed
 
-yardoc.installed: Makefile $(SOURCE_FILES) ## Generate YARD documentation
+yardoc.installed: Makefile $(wildcard config/annotations_*.rb) $(SOURCE_FILES) ## Generate YARD documentation
 	bin/yard doc $(YARD_OPTS)
 	touch yardoc.installed
 
@@ -115,7 +115,8 @@ docs: ## Generate YARD documentation
 
 clean-typecheck: ## Refresh the easily-regenerated information that type checking depends on
 	rm -fr .yardoc/ rbi/{{cookiecutter.project_slug}}.rbi types.installed yardoc.installed sig/{{cookiecutter.project_slug}}.rbs || true
-	echo all clear
+{% if cookiecutter.use_checkoff %}	rm -fr ../checkoff/.yardoc || true
+{% endif %}	echo all clear
 
 realclean-typecheck: clean-typecheck ## Remove all type checking artifacts
 	bin/solargraph clear || true
@@ -184,6 +185,7 @@ gem_dependencies: .bundle/config
 # Ensure any Gemfile.lock changes, even pulled from git, ensure a
 # bundle is installed.
 Gemfile.lock.installed: Gemfile {{cookiecutter.project_slug}}.gemspec vendor/.keep
+	bundle install
 	touch Gemfile.lock.installed
 
 vendor/.keep: Gemfile.lock .ruby-version

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -33,17 +33,27 @@ rbi/{{cookiecutter.project_slug}}.rbi: tapioca.installed yardoc.installed sorbet
 	bin/sord gen $(SORD_GEN_OPTIONS) rbi/{{cookiecutter.project_slug}}-sord.rbi # YARD to RBI
 	cat rbi/{{cookiecutter.project_slug}}-parlour.rbi rbi/{{cookiecutter.project_slug}}-sord.rbi > rbi/{{cookiecutter.project_slug}}.rbi
 	rm -f rbi/{{cookiecutter.project_slug}}-sord.rbi rbi/{{cookiecutter.project_slug}}-parlour.rbi
-#	sed -i.bak -e 's/^# typed: strong/# typed: ignore/' rbi/{{cookiecutter.project_slug}}.rbi
+	sed -i.bak -e 's/^# typed: strong/# typed: ignore/' rbi/{{cookiecutter.project_slug}}.rbi
 	rm -f rbi/{{cookiecutter.project_slug}}.rbi.bak
 	touch rbi/{{cookiecutter.project_slug}}.rbi
 
 sig/{{cookiecutter.project_slug}}.rbs: yardoc.installed .gem_rbs_collection/.keepme ## Generate RBS file
-	rm -f rbi/{{cookiecutter.project_slug}}.rbs
+	rm -f sig/{{cookiecutter.project_slug}}.rbs
 	bin/sord gen $(SORD_GEN_OPTIONS) sig/{{cookiecutter.project_slug}}.rbs # YARD to RBS
 
 YARD_PLUGIN_OPTS = --plugin yard-sorbet --plugin yard-solargraph
 
-YARD_OPTS = $(YARD_PLUGIN_OPTS) -c .yardoc --output-dir yardoc --backtrace --exclude '^config/' '{lib,app,spec,feature}/**/*.rb' 'ext/**/*.{c,rb}'
+# IMPORTANT: if you change the source globs/excludes below, bump the
+# ruby-types-vN- cache prefix in .circleci/config.yml.
+#
+# YARD's .yardoc database (cached in CI) is incremental and additive: it
+# never drops objects for files that leave the source set, so a database
+# built under one set of YARD_OPTS stays contaminated for those files
+# forever once restored.  CI fallback cache keys omit the Makefile
+# checksum, so a Makefile change alone will still restore the old
+# .yardoc.  Bumping the cache prefix forces a clean rebuild and avoids
+# shipping stale types (e.g. test-only constants) in sig/rbi.
+YARD_OPTS = $(YARD_PLUGIN_OPTS) -c .yardoc --output-dir yardoc --backtrace --exclude '^config/' --exclude '^spec/' --exclude '^feature/' '{lib,app}/**/*.rb' 'ext/**/*.{c,rb}'
 
 types.installed: tapioca.installed Gemfile.lock Gemfile.lock.installed rbi/{{cookiecutter.project_slug}}.rbi sorbet/tapioca/require.rb sorbet/config ## Ensure typechecking dependencies are in place
 	bin/solargraph gems
@@ -71,8 +81,8 @@ rbs_collection.lock.yaml: Gemfile.lock rbs_collection.yaml
 	bin/rbs collection update
 	touch rbs_collection.lock.yaml
 
-rbs_collection.yaml: Gemfile.lock.installed
-	@if [ ! -f rbs_collection.yaml ]; then bin/rbs collection init; fi
+rbs_collection.yaml:
+	bin/rbs collection init
 
 .gem_rbs_collection/.keepme: rbs_collection.lock.yaml
 	# Ensure that the gem rbs collection is installed
@@ -94,7 +104,7 @@ tapioca.installed: sorbet/tapioca/require.rb Gemfile.lock.installed ## Install T
 #	bin/tapioca dsl
 	touch tapioca.installed
 
-yardoc.installed: Makefile $(wildcard config/annotations_*.rb) $(SOURCE_FILES) ## Generate YARD documentation
+yardoc.installed: Makefile $(SOURCE_FILES) ## Generate YARD documentation
 	bin/yard doc $(YARD_OPTS)
 	touch yardoc.installed
 
@@ -105,8 +115,7 @@ docs: ## Generate YARD documentation
 
 clean-typecheck: ## Refresh the easily-regenerated information that type checking depends on
 	rm -fr .yardoc/ rbi/{{cookiecutter.project_slug}}.rbi types.installed yardoc.installed sig/{{cookiecutter.project_slug}}.rbs || true
-{% if cookiecutter.use_checkoff %}	rm -fr ../checkoff/.yardoc || true
-{% endif %}	echo all clear
+	echo all clear
 
 realclean-typecheck: clean-typecheck ## Remove all type checking artifacts
 	bin/solargraph clear || true
@@ -175,7 +184,6 @@ gem_dependencies: .bundle/config
 # Ensure any Gemfile.lock changes, even pulled from git, ensure a
 # bundle is installed.
 Gemfile.lock.installed: Gemfile {{cookiecutter.project_slug}}.gemspec vendor/.keep
-	bundle install
 	touch Gemfile.lock.installed
 
 vendor/.keep: Gemfile.lock .ruby-version
@@ -228,7 +236,7 @@ coverage: test report-coverage ## check code coverage
 	@bin/rake undercover
 
 release: sig/{{cookiecutter.project_slug}}.rbs rbi/{{cookiecutter.project_slug}}.rbi ## Create a new release
-	bundle exec rake release
+	bin/rake release
 
 report-coverage: test ## Report summary of coverage to stdout, and generate HTML, XML coverage report
 

--- a/{{cookiecutter.project_slug}}/fix.sh
+++ b/{{cookiecutter.project_slug}}/fix.sh
@@ -238,7 +238,7 @@ ensure_bundle() {
 }
 
 set_ruby_local_version() {
-  latest_ruby_version="$(cut -d' ' -f1 <<< "${ruby_versions}")"
+  latest_ruby_version="$(echo "${ruby_versions}" | tail -1)"
   if [ "${latest_ruby_version}" != "$(cat .ruby-version 2>/dev/null)" ]
   then
     echo "${latest_ruby_version}" > .ruby-version


### PR DESCRIPTION
## Summary
- Port tier-appropriate boilerplate from baked gem reference `origin/main` at `3f97e29` into cookiecutter-gem root and nested `{{cookiecutter.project_slug}}/` template.
- Nested template: bump ruby-types CI cache to v11 (with `rbs_collection.lock.yaml`), tighten YARD source excludes, fix Solargraph overcommit command, ignore `config/env.local`, fix `sig/` cleanup path, and use `bin/rake release`.
- Root maintenance tier: add CircleCI `no_output_timeout` on package init and use latest rbenv Ruby via `tail -1` in `fix.sh`.
- Per review: kept conditional `rbs_collection.yaml` init, annotations YARD dependency, checkoff `clean-typecheck` hook, `Gemfile.lock.installed` `bundle install`, and commented-out RBI `sed`.

## Test plan
- [x] `pytest tests/`
- [ ] CircleCI build on PR