### PR TITLE
Treat worktree env.local symlinks as mounted in .envrc

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -8,7 +8,9 @@ PATH_add bin
 watch_file config/env.1p
 watch_file config/env.local
 
-if [[ -r config/env.local ]]; then
+# -L: worktree symlink to mounted env.local (FIFO; -r is false without a writer).
+# -r: regular file or FIFO with an active reader/writer.
+if [[ -L config/env.local || -r config/env.local ]]; then
   # Load from mounted Environment file (empty mount => no secrets).
   if grep -qE '^[A-Z][A-Z0-9_]*=.*op://' config/env.local 2>/dev/null; then
     echo "config/env.local must contain resolved values, not op:// references." >&2

--- a/{{cookiecutter.project_slug}}/.envrc
+++ b/{{cookiecutter.project_slug}}/.envrc
@@ -8,7 +8,9 @@ PATH_add bin
 watch_file config/env.1p
 watch_file config/env.local
 
-if [[ -r config/env.local ]]; then
+# -L: worktree symlink to mounted env.local (FIFO; -r is false without a writer).
+# -r: regular file or FIFO with an active reader/writer.
+if [[ -L config/env.local || -r config/env.local ]]; then
   # Load from mounted Environment file (empty mount => no secrets).
   if grep -qE '^[A-Z][A-Z0-9_]*=.*op://' config/env.local 2>/dev/null; then
     echo "config/env.local must contain resolved values, not op:// references." >&2


### PR DESCRIPTION
## Summary
- Check `-L config/env.local` in addition to `-r` so Cursor worktrees with a symlinked Environment mount load `env.local` instead of falling through to `op run`.
- Applied at repo root and in `{{cookiecutter.project_slug}}/.envrc`.

## Test plan
- [ ] In a Cursor worktree with symlinked `config/env.local`, `direnv allow` loads secrets without `op run`
- [ ] Primary checkout with readable `config/env.local` unchanged
- [ ] No `env.local` / empty mount still uses `config/env.1p` + `op run` when populated

Made with [Cursor](https://cursor.com)