### PR TITLE
Treat worktree env.local symlinks as mounted in .envrc

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -8,7 +8,9 @@ PATH_add bin
 watch_file config/env.1p
 watch_file config/env.local
 
-if [[ -r config/env.local ]]; then
+# -L: worktree symlink to mounted env.local (FIFO; -r is false without a writer).
+# -r: regular file or FIFO with an active reader/writer.
+if [[ -L config/env.local || -r config/env.local ]]; then
   # Load from mounted Environment file (empty mount => no secrets).
   if grep -qE '^[A-Z][A-Z0-9_]*=.*op://' config/env.local 2>/dev/null; then
     echo "config/env.local must contain resolved values, not op:// references." >&2

--- a/{{cookiecutter.project_slug}}/.envrc
+++ b/{{cookiecutter.project_slug}}/.envrc
@@ -8,7 +8,9 @@ PATH_add bin
 watch_file config/env.1p
 watch_file config/env.local
 
-if [[ -r config/env.local ]]; then
+# -L: worktree symlink to mounted env.local (FIFO; -r is false without a writer).
+# -r: regular file or FIFO with an active reader/writer.
+if [[ -L config/env.local || -r config/env.local ]]; then
   # Load from mounted Environment file (empty mount => no secrets).
   if grep -qE '^[A-Z][A-Z0-9_]*=.*op://' config/env.local 2>/dev/null; then
     echo "config/env.local must contain resolved values, not op:// references." >&2


### PR DESCRIPTION
## Summary

- Add `-L config/env.local || -r …` worktree symlink guard to `.envrc` (root and nested project path).
- Keeps existing `watch_file` lines at this tier (not ported to meta).

## Test plan

- [x] `make test`
- [ ] CI green